### PR TITLE
Hide DLDI search string to stop accidental patches

### DIFF
--- a/source/dldi_patcher.c
+++ b/source/dldi_patcher.c
@@ -90,8 +90,21 @@ static addr_t quickFind (const data_t* data, const data_t* search, size_t dataLe
 	return -1;
 }
 
-static const data_t dldiMagicString[] = "\xED\xA5\x8D\xBF Chishm";	// Normal DLDI file
-static const data_t dldiMagicLoaderString[] = "\xEE\xA5\x8D\xBF Chishm";	// Different to a normal DLDI file
+// Strings are stored with bit 0x20 flipped (case inverted) to prevent accidental DLDI patching of them
+#define DLDI_MAGIC_LEN 12
+#define DLDI_MAGIC_MANGLE_VALUE 0x20
+static const data_t dldiMagicStringMangled[DLDI_MAGIC_LEN] = "\xCD\x85\xAD\x9F\0cHISHM";	// Normal DLDI file
+
+// Demangle the magic string by XORing every byte with 0x20, except the NULL terminator
+static void demangleMagicString(data_t *dest, const data_t *src) {
+	int i;
+
+	memcpy(dest, src, DLDI_MAGIC_LEN);
+	for (i = 0; i < DLDI_MAGIC_LEN - 1; ++i) {
+		dest[i] ^= DLDI_MAGIC_MANGLE_VALUE;
+	}
+}
+
 #define DEVICE_TYPE_DLDI 0x49444C44
 
 extern const u32 _io_dldi;
@@ -110,10 +123,12 @@ bool dldiPatchBinary (data_t *binData, u32 binSize) {
 	data_t *pDH;
 	data_t *pAH;
 
+	data_t dldiMagicString[DLDI_MAGIC_LEN];
 	size_t dldiFileSize = 0;
-	
+
 	// Find the DLDI reserved space in the file
-	patchOffset = quickFind (binData, dldiMagicString, binSize, sizeof(dldiMagicLoaderString));
+	demangleMagicString(dldiMagicString, dldiMagicStringMangled);
+	patchOffset = quickFind (binData, dldiMagicString, binSize, sizeof(dldiMagicString));
 
 	if (patchOffset < 0) {
 		// does not have a DLDI section


### PR DESCRIPTION
The DLDI search string, used to find DLDI sections in loaded NDS files, may be mistaken by other DLDI patchers as the start of a DLDI section. To prevent this the string is stored in a mangled state and de-mangled at run time.